### PR TITLE
Rename prod guard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
-# Prod Watch
+# Prod Guard
 
-[![Build Status](https://travis-ci.com/dotboris/prod-watch.svg?branch=master)](https://travis-ci.com/dotboris/prod-watch)
-[![Known Vulnerabilities](https://snyk.io/test/github/dotboris/prod-watch/badge.svg?targetFile=package.json)](https://snyk.io/test/github/dotboris/prod-watch?targetFile=package.json)
+[![Build Status](https://travis-ci.com/dotboris/prod-guard.svg?branch=master)](https://travis-ci.com/dotboris/prod-guard)
+[![Known Vulnerabilities](https://snyk.io/test/github/dotboris/prod-guard/badge.svg?targetFile=package.json)](https://snyk.io/test/github/dotboris/prod-guard?targetFile=package.json)
 
 Browser extension that lets you know when you're connected to production by
 giving you a clear visual cue. Never accidentally make changes to production

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "prod-watch",
+  "name": "prod-guard",
   "version": "0.0.0",
   "private": true,
   "scripts": {

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,6 +1,6 @@
 {
   "manifest_version": 2,
-  "name": "Prod Watch",
+  "name": "Prod Guard",
   "description": "Browser extension that lets you know when you're connected to production by giving you a clear visual cue. Never accidentally make changes to production ever again.",
   "version": "0.0.0",
 


### PR DESCRIPTION
Prod watch sounds a little funny, it implies that this watches production or something. While guard makes it sound like you're protecting prod which is the case with this extension