### PR TITLE
Update doc around the `master` -> `main` branch rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix bug where banners would stay invisible or partially visible when mouse
   leaves the window. [#774](https://github.com/dotboris/prod-guard/issues/774)
 
+### Changed
+
+- Rename the `master` branch to `main`. This should have 0 impact on end users
+  but it's worth mentioning.
+
 ## v1.3.0 - 2022-03-02
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -65,13 +65,13 @@ yarn package
 
 ## Release
 
-1.  Checkout `master` and make sure that you have a clean environment.
+1.  Checkout `main` and make sure that you have a clean environment.
 1.  Update the [changelog](CHANGELOG.md)
 
     You'll need to change the `Unreleased` section to the version you're about
     to release and create a new empty `Unreleased` section.
 
-    Once that's done, commit this change directly to `master`.
+    Once that's done, commit this change directly to `main`.
 
 1.  Bump the version.
 
@@ -82,7 +82,7 @@ yarn package
 1.  Push your version bump and changelog update.
 
     ```sh
-    git push --tags origin master
+    git push --tags origin main
     ```
 
 1.  Build & package the extension.


### PR DESCRIPTION
`main` is becoming the defacto standard. This PR updates the documentation to use `main` as the default branch instead of `master`. Note that the branch rename has already been done in the repo and this is only a documentation change.
