### PR TITLE
Configure dependabot & add gh actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,44 +2,16 @@ version: 2
 updates:
 - package-ecosystem: npm
   directory: "/"
+  open-pull-requests-limit: 10
   schedule:
     interval: daily
-    time: "10:00"
+  reviewers:
+    - dotboris
+
+- package-ecosystem: github-actions
+  directory: "/"
   open-pull-requests-limit: 10
-  ignore:
-  - dependency-name: webpack
-    versions:
-    - 5.25.1
-    - 5.35.0
-    - 5.35.1
-    - 5.36.0
-  - dependency-name: "@babel/core"
-    versions:
-    - 7.13.15
-  - dependency-name: karma
-    versions:
-    - 6.0.3
-    - 6.0.4
-    - 6.1.0
-    - 6.1.1
-    - 6.1.2
-    - 6.3.2
-  - dependency-name: eslint
-    versions:
-    - 7.18.0
-    - 7.19.0
-    - 7.20.0
-  - dependency-name: sass
-    versions:
-    - 1.32.5
-    - 1.32.6
-    - 1.32.7
-  - dependency-name: webpack-cli
-    versions:
-    - 4.4.0
-  - dependency-name: sass-loader
-    versions:
-    - 10.1.1
-  - dependency-name: html-webpack-plugin
-    versions:
-    - 4.5.1
+  schedule:
+    interval: daily
+  reviewers:
+    - dotboris


### PR DESCRIPTION
The config was autogenerated a while back and it only includes npm. But we have gh actions that we need to keep up to date.