### PR TITLE
Stop using `eslint-config-standard-react`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -2,7 +2,6 @@ module.exports = {
   extends: [
     'standard',
     'standard-jsx',
-    'standard-react',
     'plugin:react-hooks/recommended'
   ],
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "eslint": "^8.0.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-config-standard-jsx": "^11.0.0",
-    "eslint-config-standard-react": "^11.0.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-jest": "^26.6.0",
     "eslint-plugin-n": "^15.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,7 +14,6 @@ specifiers:
   eslint: ^8.0.0
   eslint-config-standard: ^17.0.0
   eslint-config-standard-jsx: ^11.0.0
-  eslint-config-standard-react: ^11.0.1
   eslint-plugin-import: ^2.26.0
   eslint-plugin-jest: ^26.6.0
   eslint-plugin-n: ^15.2.4
@@ -67,9 +66,8 @@ devDependencies:
   eslint: 8.22.0
   eslint-config-standard: 17.0.0_zbdqnta3mhnrvw4yywdsj5qdqy
   eslint-config-standard-jsx: 11.0.0_3wow733677dxwz5dijvkdb255q
-  eslint-config-standard-react: 11.0.1_3wow733677dxwz5dijvkdb255q
   eslint-plugin-import: 2.26.0_eslint@8.22.0
-  eslint-plugin-jest: 26.8.3_5mtwcutbsi3uflteaosuczcaoe
+  eslint-plugin-jest: 26.8.3_hxlgsl3dff2pq5fi6lzaqrpwam
   eslint-plugin-n: 15.2.4_eslint@8.22.0
   eslint-plugin-promise: 6.0.0_eslint@8.22.0
   eslint-plugin-react: 7.30.1_eslint@8.22.0
@@ -86,7 +84,7 @@ devDependencies:
   style-loader: 3.3.1_webpack@5.74.0
   stylelint: 14.10.0
   stylelint-config-standard-scss: 5.0.0_azcu7ozukcosyoqn57hruaqjcq
-  typescript: 4.7.4
+  typescript: 4.8.2
   web-ext: 7.2.0
   webpack: 5.74.0_webpack-cli@4.10.0
   webpack-clean-plugin: 0.2.3
@@ -1946,7 +1944,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: true
 
-  /@typescript-eslint/typescript-estree/5.33.1_typescript@4.7.4:
+  /@typescript-eslint/typescript-estree/5.33.1_typescript@4.8.2:
     resolution: {integrity: sha512-JOAzJ4pJ+tHzA2pgsWQi4804XisPHOtbvwUyqsuuq8+y5B5GMZs7lI1xDWs6V2d7gE/Ez5bTGojSK12+IIPtXA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1961,13 +1959,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.7.4
-      typescript: 4.7.4
+      tsutils: 3.21.0_typescript@4.8.2
+      typescript: 4.8.2
     transitivePeerDependencies:
       - supports-color
     dev: true
 
-  /@typescript-eslint/utils/5.33.1_4rv7y5c6xz3vfxwhbrcxxi73bq:
+  /@typescript-eslint/utils/5.33.1_shit3uhl6a7megkzgoz6xssnfa:
     resolution: {integrity: sha512-uphZjkMaZ4fE8CR4dU7BquOV6u0doeQAr8n6cQenl/poMaIyJtBu8eys5uk6u5HiDH01Mj5lzbJ5SfeDz7oqMQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -1976,7 +1974,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.33.1
       '@typescript-eslint/types': 5.33.1
-      '@typescript-eslint/typescript-estree': 5.33.1_typescript@4.7.4
+      '@typescript-eslint/typescript-estree': 5.33.1_typescript@4.8.2
       eslint: 8.22.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.22.0
@@ -3667,16 +3665,6 @@ packages:
       eslint-plugin-react: 7.30.1_eslint@8.22.0
     dev: true
 
-  /eslint-config-standard-react/11.0.1_3wow733677dxwz5dijvkdb255q:
-    resolution: {integrity: sha512-4WlBynOqBZJRaX81CBcIGDHqUiqxvw4j/DbEIICz8QkMs3xEncoPgAoysiqCSsg71X92uhaBc8sgqB96smaMmg==}
-    peerDependencies:
-      eslint: ^7.12.1
-      eslint-plugin-react: ^7.21.5
-    dependencies:
-      eslint: 8.22.0
-      eslint-plugin-react: 7.30.1_eslint@8.22.0
-    dev: true
-
   /eslint-config-standard/17.0.0_zbdqnta3mhnrvw4yywdsj5qdqy:
     resolution: {integrity: sha512-/2ks1GKyqSOkH7JFvXJicu0iMpoojkwB+f5Du/1SC0PtBL+s8v30k9njRZ21pm2drKYm2342jFnGWzttxPmZVg==}
     peerDependencies:
@@ -3766,7 +3754,7 @@ packages:
       - supports-color
     dev: true
 
-  /eslint-plugin-jest/26.8.3_5mtwcutbsi3uflteaosuczcaoe:
+  /eslint-plugin-jest/26.8.3_hxlgsl3dff2pq5fi6lzaqrpwam:
     resolution: {integrity: sha512-2roWu1MkEiihQ/qEszPPoaoqVI1x2D8Jtadk5AmoXTdEeNVPMu01Dtz7jIuTOAmdW3L+tSkPZOtEtQroYJDt0A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -3779,7 +3767,7 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.33.1_4rv7y5c6xz3vfxwhbrcxxi73bq
+      '@typescript-eslint/utils': 5.33.1_shit3uhl6a7megkzgoz6xssnfa
       eslint: 8.22.0
       jest: 28.1.3
     transitivePeerDependencies:
@@ -8091,14 +8079,14 @@ packages:
     resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
     dev: true
 
-  /tsutils/3.21.0_typescript@4.7.4:
+  /tsutils/3.21.0_typescript@4.8.2:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.7.4
+      typescript: 4.8.2
     dev: true
 
   /tunnel-agent/0.6.0:
@@ -8168,8 +8156,8 @@ packages:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
     dev: true
 
-  /typescript/4.7.4:
-    resolution: {integrity: sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==}
+  /typescript/4.8.2:
+    resolution: {integrity: sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==}
     engines: {node: '>=4.2.0'}
     hasBin: true
     dev: true


### PR DESCRIPTION
It's seemingly not updated anymore and pnpm complains about peer deps