### PR TITLE
Migrate from `@reach/router` to `react-router`

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,12 @@
   },
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.1.1",
-    "@reach/router": "^1.3.4",
     "raf-throttle": "^2.0.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-query": "^3.39.2",
+    "react-router": "^6.3.0",
+    "react-router-dom": "^6.3.0",
     "uuid": "^8.3.2",
     "webextension-polyfill": "^0.10.0"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,6 @@ specifiers:
   '@babel/preset-env': ^7.18.9
   '@babel/preset-react': ^7.18.6
   '@fortawesome/fontawesome-free': ^6.1.1
-  '@reach/router': ^1.3.4
   autoprefixer: ^10.4.7
   babel-loader: ^8.2.5
   copy-webpack-plugin: ^11.0.0
@@ -30,6 +29,8 @@ specifiers:
   react: ^18.2.0
   react-dom: ^18.2.0
   react-query: ^3.39.2
+  react-router: ^6.3.0
+  react-router-dom: ^6.3.0
   sass: ^1.53.0
   sass-loader: ^13.0.2
   sharp: ^0.30.7
@@ -46,11 +47,12 @@ specifiers:
 
 dependencies:
   '@fortawesome/fontawesome-free': 6.1.2
-  '@reach/router': 1.3.4_biqbaboplfbrettd7655fr4n2y
   raf-throttle: 2.0.5
   react: 18.2.0
   react-dom: 18.2.0_react@18.2.0
   react-query: 3.39.2_biqbaboplfbrettd7655fr4n2y
+  react-router: 6.3.0_react@18.2.0
+  react-router-dom: 6.3.0_biqbaboplfbrettd7655fr4n2y
   uuid: 8.3.2
   webextension-polyfill: 0.10.0
 
@@ -1731,20 +1733,6 @@ packages:
       config-chain: 1.1.13
     dev: true
 
-  /@reach/router/1.3.4_biqbaboplfbrettd7655fr4n2y:
-    resolution: {integrity: sha512-+mtn9wjlB9NN2CNnnC/BRYtwdKBfSyyasPYraNAyvaV1occr/5NnB4CVzjEZipNHwYebQwcndGUmpFzxAUoqSA==}
-    peerDependencies:
-      react: 15.x || 16.x || 16.4.0-alpha.0911da3
-      react-dom: 15.x || 16.x || 16.4.0-alpha.0911da3
-    dependencies:
-      create-react-context: 0.3.0_sh5qlbywuemxd2y3xkrw2y2kr4
-      invariant: 2.2.4
-      prop-types: 15.8.1
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      react-lifecycles-compat: 3.0.4
-    dev: false
-
   /@sinclair/typebox/0.24.19:
     resolution: {integrity: sha512-gHJu8cdYTD5p4UqmQHrxaWrtb/jkH5imLXzuBypWhKzNkW0qfmgz+w1xaJccWVuJta1YYUdlDiPHXRTR4Ku0MQ==}
     dev: true
@@ -3152,18 +3140,6 @@ packages:
       yaml: 1.10.2
     dev: true
 
-  /create-react-context/0.3.0_sh5qlbywuemxd2y3xkrw2y2kr4:
-    resolution: {integrity: sha512-dNldIoSuNSvlTJ7slIKC/ZFGKexBMBrrcc+TTe1NdmROnaASuLPvqpwj9v4XS4uXZ8+YPu0sNmShX2rXI5LNsw==}
-    peerDependencies:
-      prop-types: ^15.0.0
-      react: ^0.14.0 || ^15.0.0 || ^16.0.0
-    dependencies:
-      gud: 1.0.0
-      prop-types: 15.8.1
-      react: 18.2.0
-      warning: 4.0.3
-    dev: false
-
   /cross-env/7.0.3:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
@@ -4545,10 +4521,6 @@ packages:
     resolution: {integrity: sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==}
     dev: true
 
-  /gud/1.0.0:
-    resolution: {integrity: sha512-zGEOVKFM5sVPPrYs7J5/hYEw2Pof8KCyOwyhG8sAF26mCAeUFAcYPu1mwB7hhpIP29zOIBaDqwuHdLp0jvZXjw==}
-    dev: false
-
   /har-schema/2.0.0:
     resolution: {integrity: sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==}
     engines: {node: '>=4'}
@@ -4616,6 +4588,12 @@ packages:
     resolution: {integrity: sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==}
     hasBin: true
     dev: true
+
+  /history/5.3.0:
+    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
+    dependencies:
+      '@babel/runtime': 7.18.9
+    dev: false
 
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
@@ -4811,12 +4789,6 @@ packages:
     resolution: {integrity: sha512-Ju0Bz/cEia55xDwUWEa8+olFpCiQoypjnQySseKtmjNrnps3P+xfpUmGr90T7yjlVJmOtybRvPXhKMbHr+fWnw==}
     engines: {node: '>= 0.10'}
     dev: true
-
-  /invariant/2.2.4:
-    resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
   /invert-kv/3.0.1:
     resolution: {integrity: sha512-CYdFeFexxhv/Bcny+Q0BfOV+ltRlJcd4BBZBYFX/O0u4npJrgZtIcjokegtiSMAvlMTJ+Koq0GBCc//3bueQxw==}
@@ -6279,6 +6251,7 @@ packages:
   /object-assign/4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /object-inspect/1.12.0:
     resolution: {integrity: sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==}
@@ -6807,6 +6780,7 @@ packages:
       loose-envify: 1.4.0
       object-assign: 4.1.1
       react-is: 16.13.1
+    dev: true
 
   /proto-list/1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
@@ -6896,14 +6870,11 @@ packages:
 
   /react-is/16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+    dev: true
 
   /react-is/18.0.0:
     resolution: {integrity: sha512-yUcBYdBBbo3QiPsgYDcfQcIkGZHfxOaoE6HLSnr1sPzMhdyxusbfKOSUbSd/ocGi32dxcj366PsTj+5oggeKKw==}
     dev: true
-
-  /react-lifecycles-compat/3.0.4:
-    resolution: {integrity: sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==}
-    dev: false
 
   /react-query/3.39.2_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-F6hYDKyNgDQfQOuR1Rsp3VRzJnWHx6aRnnIZHMNGGgbL3SBgpZTDg8MQwmxOgpCAoqZJA+JSNCydF1xGJqKOCA==}
@@ -6922,6 +6893,27 @@ packages:
       match-sorter: 6.3.0
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
+    dev: false
+
+  /react-router-dom/6.3.0_biqbaboplfbrettd7655fr4n2y:
+    resolution: {integrity: sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==}
+    peerDependencies:
+      react: '>=16.8'
+      react-dom: '>=16.8'
+    dependencies:
+      history: 5.3.0
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      react-router: 6.3.0_react@18.2.0
+    dev: false
+
+  /react-router/6.3.0_react@18.2.0:
+    resolution: {integrity: sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      history: 5.3.0
+      react: 18.2.0
     dev: false
 
   /react/18.2.0:
@@ -8312,12 +8304,6 @@ packages:
     dependencies:
       makeerror: 1.0.12
     dev: true
-
-  /warning/4.0.3:
-    resolution: {integrity: sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==}
-    dependencies:
-      loose-envify: 1.4.0
-    dev: false
 
   /watchpack/2.4.0:
     resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}

--- a/src/popup/app.jsx
+++ b/src/popup/app.jsx
@@ -1,15 +1,15 @@
 import React from 'react'
-import { Router } from '@reach/router'
 import WarningsListPage from './warnings/list-page'
 import NewWarningPage from './warnings/new-page'
 import EditWarningPage from './warnings/edit-page'
+import { Routes, Route } from 'react-router'
 
 export default function App () {
   return (
-    <Router>
-      <WarningsListPage path='/' default />
-      <NewWarningPage path='/new' />
-      <EditWarningPage path='/edit/:id' />
-    </Router>
+    <Routes>
+      <Route path='*' element={<WarningsListPage />} />
+      <Route path='/new' element={<NewWarningPage />} />
+      <Route path='/edit/:id' element={<EditWarningPage />} />
+    </Routes>
   )
 }

--- a/src/popup/app.jsx
+++ b/src/popup/app.jsx
@@ -3,11 +3,14 @@ import WarningsListPage from './warnings/list-page'
 import NewWarningPage from './warnings/new-page'
 import EditWarningPage from './warnings/edit-page'
 import { Routes, Route } from 'react-router'
+import { Redirect } from './redirect'
 
 export default function App () {
   return (
     <Routes>
-      <Route path='*' element={<WarningsListPage />} />
+      {/* The popup starts at /popup.html. We normalize that to / */}
+      <Route path='/popup.html' element={<Redirect to='/' />} />
+      <Route path='/' element={<WarningsListPage />} />
       <Route path='/new' element={<NewWarningPage />} />
       <Route path='/edit/:id' element={<EditWarningPage />} />
     </Routes>

--- a/src/popup/index.jsx
+++ b/src/popup/index.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import { render } from 'react-dom'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import App from './app'
+import { LocationProvider } from '@reach/router'
 
 main()
 
@@ -14,9 +15,11 @@ async function main () {
   const queryClient = new QueryClient()
 
   render(
-    <QueryClientProvider client={queryClient}>
-      <App />
-    </QueryClientProvider>,
+    <LocationProvider>
+      <QueryClientProvider client={queryClient}>
+        <App />
+      </QueryClientProvider>
+    </LocationProvider>,
     root
   )
 }

--- a/src/popup/index.jsx
+++ b/src/popup/index.jsx
@@ -1,25 +1,25 @@
 import './index.scss'
 import React from 'react'
-import { render } from 'react-dom'
+import { createRoot } from 'react-dom/client'
 import { QueryClient, QueryClientProvider } from 'react-query'
 import App from './app'
-import { LocationProvider } from '@reach/router'
+import { BrowserRouter } from 'react-router-dom'
 
 main()
 
 async function main () {
-  const root = document.createElement('div')
-  root.className = 'app-root'
-  document.body.append(root)
+  const rootElement = document.createElement('div')
+  rootElement.className = 'app-root'
+  document.body.append(rootElement)
 
   const queryClient = new QueryClient()
 
-  render(
-    <LocationProvider>
+  const root = createRoot(rootElement)
+  root.render(
+    <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <App />
       </QueryClientProvider>
-    </LocationProvider>,
-    root
+    </BrowserRouter>
   )
 }

--- a/src/popup/layout.jsx
+++ b/src/popup/layout.jsx
@@ -1,6 +1,6 @@
 import './layout.scss'
 import React from 'react'
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 import Icon from './icon'
 import HomeIcon from '@fortawesome/fontawesome-free/svgs/solid/house-chimney.svg'
 

--- a/src/popup/redirect.jsx
+++ b/src/popup/redirect.jsx
@@ -1,0 +1,15 @@
+import { useEffect } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+
+// `react-router` doesn't have a client side redirect component.
+// We need to do client side redirect here because there's no server so we
+// implement one ourselves.
+export function Redirect ({ to }) {
+  const location = useLocation()
+  const navigate = useNavigate()
+  useEffect(() => {
+    console.log(`Redirecting from ${location.pathname} to ${to}`)
+    navigate(to)
+  }, [navigate, to, location])
+  return null
+}

--- a/src/popup/warnings/edit-page.jsx
+++ b/src/popup/warnings/edit-page.jsx
@@ -1,18 +1,19 @@
-import { navigate, useParams } from '@reach/router'
 import React, { useCallback } from 'react'
 import Layout from '../layout'
 import { useWarning, useUpdateWarningMutation } from './state'
 import WarningForm from './form'
+import { useParams, useNavigate } from 'react-router'
 
 export default function EditWarningPage () {
   const updateWarningMutation = useUpdateWarningMutation()
   const { id } = useParams()
   const { isLoading, data: warning } = useWarning(id)
 
+  const navigate = useNavigate()
   const handleSave = useCallback(async warning => {
     await updateWarningMutation.mutateAsync({ id, warning })
     navigate('/')
-  }, [updateWarningMutation, id])
+  }, [updateWarningMutation, id, navigate])
 
   return (
     <Layout title='Edit Warning'>

--- a/src/popup/warnings/list-page.jsx
+++ b/src/popup/warnings/list-page.jsx
@@ -6,7 +6,7 @@ import EditIcon from '@fortawesome/fontawesome-free/svgs/solid/pen-to-square.svg
 import TrashIcon from '@fortawesome/fontawesome-free/svgs/solid/trash.svg'
 import Layout from '../layout'
 import { useAllWarnings, useRemoveWarningMutation } from './state'
-import { Link } from '@reach/router'
+import { Link } from 'react-router-dom'
 
 export default function WarningsListPage () {
   return (

--- a/src/popup/warnings/new-page.jsx
+++ b/src/popup/warnings/new-page.jsx
@@ -3,8 +3,8 @@ import browser from 'webextension-polyfill'
 import WarningForm from './form'
 import Layout from '../layout'
 import { useAddWarningMutation } from './state'
-import { navigate } from '@reach/router'
 import { useQuery } from 'react-query'
+import { useNavigate } from 'react-router'
 
 export default function NewWarningPage () {
   const {
@@ -13,10 +13,11 @@ export default function NewWarningPage () {
   } = useSuggestedPattern()
   const addWarningMutation = useAddWarningMutation()
 
+  const navigate = useNavigate()
   const handleSave = useCallback(async warning => {
     await addWarningMutation.mutateAsync({ warning })
     navigate('/')
-  }, [addWarningMutation])
+  }, [addWarningMutation, navigate])
 
   return (
     <Layout title='New Warning'>


### PR DESCRIPTION
`@reach/router` and `react-router` are merging into `react-router@6`. We're moving along and merging to that.

We need to upgrade in this context because `@reach/router` doesn't support modern react versions and this leads to `pnpm` getting rightfully upset over peer dependencies.